### PR TITLE
Uses `text-decoration` to style `abbr` tags if available. Fixes #274

### DIFF
--- a/src/sass/type/_typography.sass
+++ b/src/sass/type/_typography.sass
@@ -277,6 +277,9 @@ $placeholderText-fallback: true !default
 %abbr
   border-bottom: 1px dotted
   cursor: help
+  @supports (text-decoration: dotted underline)
+    text-decoration: dotted underline
+    border-bottom: none
 
 %pre
   @extend %monospace


### PR DESCRIPTION
If `text-decoration` is not available we fall back to `border-bottom`.

Should I also commit the compiled files?